### PR TITLE
header and footer adjustments

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,8 +15,9 @@ import GlobalStyle from "./styles/GlobalStyle";
 import Signup from "./components/Signup/Signup";
 import Profile from "./components/Profile/Profile";
 import CaregiverProfile from "./components/Profile/Caregiver_profile";
-import Calendar from "./components/Calendar/Calendar";
 import CalendarPage from "./components/Calendar/Calendar";
+import Header from "./components/Header";
+import UnderConstruction from "./components/UnderConstructionPage";
 
 function App() {
   return (
@@ -24,6 +25,7 @@ function App() {
       <GlobalStyle />
       <div className="content">
         <Router>
+          <Header />
           <Routes>
             <Route path="/login" element={<Login />} />
             <Route path="/unauthorized" element={<Unauthorized />} />
@@ -35,6 +37,7 @@ function App() {
                 </RequireAuth>
               }
             />
+            <Route path="/underconstruction" element={<UnderConstruction />} />
             <Route
               path="/admin/dashboard"
               element={

--- a/src/components/AdminDashboard.jsx
+++ b/src/components/AdminDashboard.jsx
@@ -41,22 +41,22 @@ function AdminDashboard() {
         <ButtonLink
           picture="/vite.svg"
           linkName="Appointment"
-          link="/signup"
+          link="/underconstruction"
         ></ButtonLink>
         <ButtonLink
           picture="/vite.svg"
           linkName="Calendar"
-          link=""
+          link="/underconstruction"
         ></ButtonLink>
         <ButtonLink
           picture="/vite.svg"
           linkName="Notifications"
-          link=""
+          link="/underconstruction"
         ></ButtonLink>
         <ButtonLink
           picture="/vite.svg"
           linkName="Your Feedback"
-          link=""
+          link="/underconstruction"
         ></ButtonLink>
       </div>
       <Logout />

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,0 +1,73 @@
+import { useState, useEffect } from "react";
+import styled from "styled-components";
+import { useLocation, useNavigate } from "react-router-dom";
+
+const Header = () => {
+  const HeaderContainer = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: start;
+    flex-direction: row;
+    border-bottom: 1px solid black;
+    height: 3rem;
+    width: 100%;
+  `;
+  const ReturnButton = styled.button`
+    color: black;
+    background-color: white;
+    border-style: none;
+    border: 1px solid gray;
+    border-radius: 8px;
+    padding: 2px 10px 2px 10px;
+    font-size: medium;
+
+    &:hover {
+      background-color: #057d7a;
+      cursor: pointer;
+      color: white;
+    }
+  `;
+
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [historyStack, setHistoryStack] = useState([]);
+  const hiddenPaths = ["/login", "/signup"];
+
+  useEffect(() => {
+    const currentPath = location.pathname;
+
+    setHistoryStack((prevStack) => {
+      if (prevStack[prevStack.length - 1] === currentPath) {
+        return prevStack;
+      }
+      return [...prevStack, currentPath];
+    });
+  }, [location.pathname]);
+
+  const handleReturn = () => {
+    setHistoryStack((prevStack) => {
+      const updatedStack = [...prevStack];
+      updatedStack.pop();
+      const previousPath = updatedStack[updatedStack.length - 1];
+      navigate(previousPath);
+      return updatedStack;
+    });
+  };
+
+  const canGoBack =
+    historyStack.length > 1 && // Ensure there is a previous page in the stack
+    !hiddenPaths.includes(historyStack[historyStack.length - 2]) &&
+    historyStack[historyStack.length - 2] !== location.pathname;
+
+  if (hiddenPaths.includes(location.pathname)) {
+    return null;
+  }
+
+  return (
+    <HeaderContainer>
+      {canGoBack && <ReturnButton onClick={handleReturn}>return</ReturnButton>}
+    </HeaderContainer>
+  );
+};
+
+export default Header;

--- a/src/components/UnderConstructionPage.jsx
+++ b/src/components/UnderConstructionPage.jsx
@@ -1,0 +1,18 @@
+import styled from "styled-components";
+
+const UnderConstruction = () => {
+  const ConstructionContainer = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-direction: column;
+  `;
+  return (
+    
+      <ConstructionContainer>
+        <h3>This page is still under construction.</h3>
+      </ConstructionContainer>
+      
+  );
+};
+export default UnderConstruction;

--- a/src/components/UserDashboard.jsx
+++ b/src/components/UserDashboard.jsx
@@ -43,12 +43,12 @@ function UserDashboard() {
         <ButtonLink
           picture="/vite.svg"
           linkName="Book Doctor"
-          link="/login"
+          link="/underconstruction"
         ></ButtonLink>
         <ButtonLink
           picture="/vite.svg"
           linkName="Appointment"
-          link="/signup"
+          link="/underconstruction"
         ></ButtonLink>
         <ButtonLink
           picture="/vite.svg"
@@ -58,12 +58,12 @@ function UserDashboard() {
         <ButtonLink
           picture="/vite.svg"
           linkName="Notifications"
-          link=""
+          link="/underconstruction"
         ></ButtonLink>
         <ButtonLink
           picture="/vite.svg"
           linkName="Give Feedback"
-          link=""
+          link="/underconstruction"
         ></ButtonLink>
       </div>
       <Logout />

--- a/src/components/footer/Footer.css
+++ b/src/components/footer/Footer.css
@@ -1,34 +1,39 @@
 .footer {
-    position: fixed;
-    bottom: 0;
-    width: 100%;
-    background-color: #f8f9fa;
-    border-top: 1px solid #dee2e6;
-    padding: 10px 0;
-    display: flex;
-    justify-content: center;
-  }
-  
-  .footer-nav {
-    display: flex;
-    justify-content: space-around;
-    width: 100%;
-    max-width: 600px;
-  }
-  
-  .footer-link {
-    text-decoration: none;
-    color: #333;
-    text-align: center;
-    font-size: 14px;
-  }
-  
-  .footer-link .icon {
-    display: block;
-    font-size: 20px;
-    margin-bottom: 4px;
-  }
-  
-  .footer-link:hover {
-    color: #007bff;
-  }
+  position: fixed;
+  bottom: 0;
+  width: 100%;
+  background-color: #f8f9fa;
+  border-top: 1px solid #dee2e6;
+  padding: 10px 0;
+  display: flex;
+  justify-content: center;
+}
+
+.footer-nav {
+  display: flex;
+  justify-content: space-around;
+  width: 100%;
+  max-width: 600px;
+}
+
+.footer-link {
+  text-decoration: none;
+  color: #333;
+  text-align: center;
+  font-size: 14px;
+  border-style: none;
+  padding: 4px 10px 4px 10px;
+  border-radius: 8px;
+  background-color: #f8f9fa;
+}
+
+.footer-link .icon {
+  display: block;
+  font-size: 20px;
+  margin-bottom: 4px;
+}
+
+.footer-link:hover {
+  color: #007bff;
+  cursor: pointer;
+}

--- a/src/components/footer/Footer.jsx
+++ b/src/components/footer/Footer.jsx
@@ -1,22 +1,24 @@
 import React from "react";
 import "./Footer.css";
+import { useNavigate, useLocation } from "react-router-dom";
 
 const Footer = ({ userType }) => {
-  const UserLinks = [
-    { name: "Hem", path: "/" },
-    { name: "Something1", path: "/something" },
-  ];
+  const navigate = useNavigate();
+  const location = useLocation();
+  const UserLinks = [{ name: "Something1", path: "/underconstruction" }];
 
   const doctorLinks = [
-    { name: "Something2", path: "/" },
-    { name: "Something3", path: "/" },
+    { name: "Hem", path: "/admin/dashboard" },
+    { name: "Something2", path: "/underconstruction" },
+    { name: "Something3", path: "/underconstruction" },
     { name: "Profile", path: "/caregiverprofile" },
   ];
 
   const patientLinks = [
+    { name: "Hem", path: "/user/dashboard" },
     { name: "Profile", path: "/profile" },
-    { name: "Something4", path: "/" },
-    { name: "Something5", path: "/" },
+    { name: "Something4", path: "/underconstruction" },
+    { name: "Something5", path: "/underconstruction" },
   ];
 
   const links = [
@@ -25,14 +27,24 @@ const Footer = ({ userType }) => {
     ...(userType === "patient" ? patientLinks : []),
   ];
 
+  const handleNavigate = (e) => {
+    navigate(e);
+  };
+
   return (
     <footer className="footer">
       <nav className="footer-nav">
-        {links.map((link) => (
-          <a key={link.name} href={link.path} className="footer-link">
-            <span className="label">{link.name}</span>
-          </a>
-        ))}
+      {links
+          .filter((link) => link.path !== location.pathname) 
+          .map((link) => (
+            <button
+              key={link.name}
+              onClick={() => handleNavigate(link.path)}
+              className="footer-link"
+            >
+              <span className="label">{link.name}</span>
+            </button>
+          ))}
       </nav>
     </footer>
   );


### PR DESCRIPTION
## Vad är gjort
- Header som är synlig där den ska (inte /login eller /signup) se:
![Screenshot 2025-01-02 at 16 57 43](https://github.com/user-attachments/assets/30fb1446-fd14-4a41-ae9a-96c7db98bd4f)

- Lagrar historik så:
man inte kan returnera till login eller signup
man inte kan returnera om man kommer utifrån och inte har någonstans att returnera till
man kan inte returnera om return är samma som sidan man står på

- fixat footer så den använder navigate istället för href (så den ändrar innehåll utan refresh)
- fixat footer så den knapp man står vid inte syns, tex profil när man redan är på profil 

- en under construction sida som man kommer till om man klickar på alla existerande knappar som inte leder någonstans, som helt enkelt inte är helt klara ännu.

## Vad ska testat och hur
- Klicka runt lite och testa

## Annat 
- Recenserare: 1 
- Acceptera inget som inte är korrekt, har du synpunkter så skriv det nedan så fixar jag.



Closes #15 