### PR TITLE
Appointment History

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -23,6 +23,8 @@ import UnderConstruction from "./components/UnderConstructionPage";
 import Footer from "./components/footer/Footer";
 import Appointment_info from "./components/Appointment-info/A_info";
 import Schedule from "./components/Schedule/Schedule";
+import MeetingHistory from "./pages/appointmentHistory/AppointmentHistory";
+import AppointmentHistory from "./pages/appointmentHistory/AppointmentHistory";
 
 function App() {
   return (
@@ -47,6 +49,14 @@ function App() {
               element={
                 <RequireAuth allowedRoles={["USER", "ADMIN"]}>
                   <Appointment_info />
+                </RequireAuth>
+              }
+            />
+            <Route
+              path="/appointment/history"
+              element={
+                <RequireAuth allowedRoles={["USER", "ADMIN"]}>
+                  <AppointmentHistory />
                 </RequireAuth>
               }
             />

--- a/src/components/AdminDashboard.jsx
+++ b/src/components/AdminDashboard.jsx
@@ -49,8 +49,8 @@ function AdminDashboard() {
         ></ButtonLink>
         <ButtonLink
           picture="/vite.svg"
-          linkName="Notifications"
-          link="/underconstruction"
+          linkName="Appointment History"
+          link="/appointment/history"
         ></ButtonLink>
         <ButtonLink
           picture="/vite.svg"

--- a/src/components/UserDashboard.jsx
+++ b/src/components/UserDashboard.jsx
@@ -51,8 +51,8 @@ function UserDashboard() {
         ></ButtonLink>
         <ButtonLink
           picture="/vite.svg"
-          linkName="Notifications"
-          link="/underconstruction"
+          linkName="Appointment History"
+          link="/appointment/history"
         ></ButtonLink>
         <ButtonLink
           picture="/vite.svg"

--- a/src/pages/appointmentHistory/AppointmentHistory.css
+++ b/src/pages/appointmentHistory/AppointmentHistory.css
@@ -1,0 +1,67 @@
+.mainContainerAppsHistory {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  height: 100%;
+  width: 100%;
+}
+
+.appsHistoryContainer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: row;
+  width: 80%;
+  height: auto;
+  background-color: #057d7a;
+  border-radius: 15px;
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+  gap: 1rem;
+  list-style: none;
+  flex-wrap: wrap;
+  padding-left: 0;
+  padding-right: 0;
+}
+
+.appsHistoryBox {
+  background-color: white;
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  min-width: 13rem;
+}
+.appsHistoryBox p {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  margin: 0.3rem;
+}
+.completedHistory {
+  color: green;
+}
+.appsHistoryInnerBox {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: row;
+  gap: 0.2rem;
+  padding-left: 0.2rem;
+  padding-right: 0.2rem;
+}
+
+.appHistPagiButton {
+  color: black;
+  margin: 0.1rem;
+}
+
+.summaryAppHist {
+  width: 80%;
+  flex-wrap: wrap;
+  text-align: center;
+  height: auto;
+}

--- a/src/pages/appointmentHistory/AppointmentHistory.jsx
+++ b/src/pages/appointmentHistory/AppointmentHistory.jsx
@@ -1,0 +1,174 @@
+import "./AppointmentHistory.css";
+import { useState, useEffect } from "react";
+import axios from "axios";
+
+const AppointmentHistory = () => {
+  const [appointments, setAppointments] = useState([]);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [loading, setLoading] = useState(false);
+  const [option, setOption] = useState();
+  const username = localStorage.getItem("loggedInUsername");
+
+  const itemsPerPage = 10;
+
+  const [role, setRole] = useState(null);
+
+  const fetchRole = async () => {
+    try {
+      const response = await axios.get(
+        `${import.meta.env.VITE_API_URL}/auth/check`,
+        { withCredentials: true }
+      );
+      setRole(response.data.roles ? response.data.roles[0] : undefined);
+    } catch (error) {}
+  };
+
+  useEffect(() => {
+    fetchRole();
+  }, []);
+
+  useEffect(() => {
+    if (role !== null) {
+      setOptionAlternative();
+    }
+  }, [role]);
+
+  useEffect(() => {
+    if (option) {
+      fetchAppointments();
+    }
+  }, [option]);
+
+  const setOptionAlternative = () => {
+    if (option !== "1" && option !== "2") {
+      if (role === "USER") {
+        setOption("1");
+      } else if (role === "ADMIN") {
+        setOption("2");
+      }
+    }
+  };
+
+  const fetchAppointments = async () => {
+    setLoading(true);
+    try {
+      const response = await axios.get(
+        `${
+          import.meta.env.VITE_API_URL
+        }/appointment/history/${option}/${username}`,
+        {
+          withCredentials: true,
+        }
+      );
+
+      // Get usernames and format date/time
+      const appointmentsWithUsernames = await Promise.all(
+        response.data.map(async (appointment) => {
+          const patientFullName = await fetchFullName(appointment.patientId);
+          const caregiverFullName = await fetchFullName(
+            appointment.caregiverId
+          );
+
+          // Format date and time
+          const dateObject = new Date(appointment.dateTime);
+          const formattedDate = dateObject.toISOString().split("T")[0].slice(2);
+          const formattedTime = dateObject
+            .toTimeString()
+            .split(":")
+            .slice(0, 2)
+            .join(":");
+
+          return {
+            ...appointment,
+            patientFullName,
+            caregiverFullName,
+            formattedDate,
+            formattedTime,
+          };
+        })
+      );
+
+      console.log(appointmentsWithUsernames);
+      setAppointments(appointmentsWithUsernames);
+    } catch (error) {
+      console.log("Error fetching appointments:", error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const fetchFullName = async (userId) => {
+    try {
+      const response = await axios.get(
+        `${import.meta.env.VITE_API_URL}/user/full-name/${userId}`,
+        {
+          withCredentials: true,
+        }
+      );
+      return response.data;
+    } catch (error) {
+      console.log("Error fetching names:", error);
+    }
+  };
+
+  const indexOfLastItem = currentPage * itemsPerPage;
+  const indexOfFirstItem = indexOfLastItem - itemsPerPage;
+  const currentAppointments = appointments.slice(
+    indexOfFirstItem,
+    indexOfLastItem
+  );
+
+  const totalPages = Math.ceil(appointments.length / itemsPerPage);
+
+  const handlePageChange = (page) => {
+    setCurrentPage(page);
+  };
+
+  return (
+    <div className="mainContainerAppsHistory">
+      <h1>Appointment History</h1>
+      {loading ? (
+        <p>Loading...</p>
+      ) : (
+        <>
+          <ul className="appsHistoryContainer">
+            {currentAppointments.map((appointment, index) => (
+              <li className="appsHistoryBox" key={appointment.id || index}>
+                <p className="completedHistory">{appointment.status}</p>
+                <div className="appsHistoryInnerBox">
+                  <p>
+                    <strong>Patient</strong> {appointment.patientFullName}
+                  </p>
+                  <p>
+                    <strong>Doctor</strong> {appointment.caregiverFullName}
+                  </p>
+                </div>
+                <p className="summaryAppHist">
+                  <strong>Summary:</strong>
+                  {appointment.summary}
+                </p>
+                <p>
+                  <strong>Date and Time:</strong>
+                  {appointment.formattedDate} {"-"} {appointment.formattedTime}
+                </p>
+              </li>
+            ))}
+          </ul>
+          <div>
+            {Array.from({ length: totalPages }, (_, index) => (
+              <button
+                className="appHistPagiButton"
+                key={index}
+                onClick={() => handlePageChange(index + 1)}
+                disabled={currentPage === index + 1}
+              >
+                {index + 1}
+              </button>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+export default AppointmentHistory;


### PR DESCRIPTION
whats done:
* en ny sida med historik av alla appointments som är completed
* sorteras i datum ordning senast -> äldst
* pagination, 10 per sida
* hämtar automatiskt användarens roll och anpassar sidan därefter vad som ska visas och inte visas

how to test:

KÖRS IHOP MED BRANCH 18 I BACKEND OM INTE DEN ÄR MERGED TILL DEV

logga in med ett konto som har completed appointments tex:
user: username: viktor , lösen: viktor1
admin: pedro pedro1


 - [x] logga in som user med appointments som är COMPLETED 
- [x] klicka in på appointment history:
![image](https://github.com/user-attachments/assets/d5d72d0c-6fba-47d2-ba59-5f2c3e6736b0)

Där kommer sidan laddas med rätt data.

* testa pagination
 - [x] I appointmentHistory.jsx , hitta denna och ändra till typ 2 
![image](https://github.com/user-attachments/assets/daaf5071-251c-4fcd-b244-7d6014029230)
så blir det fler sidor
![image](https://github.com/user-attachments/assets/8f28576a-34db-4d4d-8b5f-3d5c35a02fdb)
 - [x] ändra tillbaka till 10 igen

 - [x] testa design, responsivitet med mera

 - [x] gör samma sak fast inloggad som admin

other:

Några synpunkter? let me know in the comments


Closes #37 