### PR TITLE
appointment info, admin to doctor role fix

### DIFF
--- a/src/components/Appointment-info/A_info.jsx
+++ b/src/components/Appointment-info/A_info.jsx
@@ -245,7 +245,7 @@ const Appointment_info = () => {
         </p>
       </div>
 
-      {!role ? undefined : role === "ADMIN" ? (
+      {!role ? undefined : role === "DOCTOR" ? (
         <>
           <div className="appointmentButtonContainer">
             <button className="appointmentButton" onClick={handleEdit}>


### PR DESCRIPTION
Ändrade från ADMIN till DOCTOR på appointment info så doctor kan använda edit appointment istället för request mail som user använder.

testas genom att:

- [x] Logga in som doctor, klicka in på en incoming appointment som är bortom 24h. Kolla så man kan ändra status via edit.
- [x] Logga in som doctor och välj en incoming appointment som är inom 24h, titta så man kan skicka mail med subject och text till patienten.